### PR TITLE
Add h5py as GH actions tests

### DIFF
--- a/.github/workflows/github-build-test.yml
+++ b/.github/workflows/github-build-test.yml
@@ -384,7 +384,7 @@ jobs:
 
     - name: Setup python dependencies
       run: |
-        pip install numpy coverage
+        pip install numpy coverage h5py
 
     - name: Download prebuild python-gpt
       uses: actions/download-artifact@v2


### PR DESCRIPTION
To fix the failing tests, and to be able to use/test the hdf5 output it should be as easy as to install the h5py dependency in the Github actions.

Edit, see for example: https://github.com/aragon999/gpt/runs/1332248822?check_suite_focus=true